### PR TITLE
Move README to root and describe GUI and venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,43 @@ sudo apt-get install ffmpeg
 conda install "ffmpeg<5" -c conda-forge
 ```
 
+## Virtual Environment
+
+It is recommended to work within a dedicated Python virtual environment to keep
+dependencies isolated. You can create one using `venv`:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+Alternatively, you can use Conda:
+
+```bash
+conda create -n audiocraft python=3.9
+conda activate audiocraft
+```
+
+Once activated, follow the installation commands above.
+
 ## Models
 
 At the moment, AudioCraft contains the training code and inference code for:
-* [MusicGen](./docs/MUSICGEN.md): A state-of-the-art controllable text-to-music model.
-* [AudioGen](./docs/AUDIOGEN.md): A state-of-the-art text-to-sound model.
-* [EnCodec](./docs/ENCODEC.md): A state-of-the-art high fidelity neural audio codec.
-* [Multi Band Diffusion](./docs/MBD.md): An EnCodec compatible decoder using diffusion.
-* [MAGNeT](./docs/MAGNET.md): A state-of-the-art non-autoregressive model for text-to-music and text-to-sound.
-* [AudioSeal](./docs/WATERMARKING.md): A state-of-the-art audio watermarking.
-* [MusicGen Style](./docs/MUSICGEN_STYLE.md): A state-of-the-art text-and-style-to-music model.
-* [JASCO](./docs/JASCO.md): "High quality text-to-music model conditioned on chords, melodies and drum tracks"
+* [MusicGen](./audiocraft/docs/MUSICGEN.md): A state-of-the-art controllable text-to-music model.
+* [AudioGen](./audiocraft/docs/AUDIOGEN.md): A state-of-the-art text-to-sound model.
+* [EnCodec](./audiocraft/docs/ENCODEC.md): A state-of-the-art high fidelity neural audio codec.
+* [Multi Band Diffusion](./audiocraft/docs/MBD.md): An EnCodec compatible decoder using diffusion.
+* [MAGNeT](./audiocraft/docs/MAGNET.md): A state-of-the-art non-autoregressive model for text-to-music and text-to-sound.
+* [AudioSeal](./audiocraft/docs/WATERMARKING.md): A state-of-the-art audio watermarking.
+* [MusicGen Style](./audiocraft/docs/MUSICGEN_STYLE.md): A state-of-the-art text-and-style-to-music model.
+* [JASCO](./audiocraft/docs/JASCO.md): "High quality text-to-music model conditioned on chords, melodies and drum tracks"
 
 
 ## Training code
 
 AudioCraft contains PyTorch components for deep learning research in audio and training pipelines for the developed models.
 For a general introduction of AudioCraft design principles and instructions to develop your own training pipeline, refer to
-the [AudioCraft training documentation](./docs/TRAINING.md).
+the [AudioCraft training documentation](./audiocraft/docs/TRAINING.md).
 
 For reproducing existing work and using the developed training pipelines, refer to the instructions for each specific model
 that provides pointers to configuration, example grids and model/task-specific information and FAQ.
@@ -58,11 +77,37 @@ that provides pointers to configuration, example grids and model/task-specific i
 We provide some [API documentation](https://facebookresearch.github.io/audiocraft/api_docs/audiocraft/index.html) for AudioCraft.
 
 
+## Execution and GUI
+
+After installing the package you can generate music through command line scripts
+or graphical interfaces.
+
+### Gradio demos
+The `audiocraft/demos` folder contains several [Gradio](https://www.gradio.app/)
+applications. To launch the MusicGen demo locally run:
+
+```bash
+python -m audiocraft.demos.musicgen_app --share
+```
+
+Add `--share` to create a publicly shareable link. Similar commands can be used
+for `magnet_app.py` and `jasco_app.py`.
+
+### PyQt GUI
+If you prefer a desktop application, run the PyQt interface:
+
+```bash
+python audiocraft/generate_music.py
+```
+
+This opens a window where you can type prompts and generate short clips
+offline.
+
 ## FAQ
 
 #### Is the training code available?
 
-Yes! We provide the training code for [EnCodec](./docs/ENCODEC.md), [MusicGen](./docs/MUSICGEN.md),[Multi Band Diffusion](./docs/MBD.md) and [JASCO](./docs/JASCO.md).
+Yes! We provide the training code for [EnCodec](./audiocraft/docs/ENCODEC.md), [MusicGen](./audiocraft/docs/MUSICGEN.md),[Multi Band Diffusion](./audiocraft/docs/MBD.md) and [JASCO](./audiocraft/docs/JASCO.md).
 
 #### Where are the models stored?
 
@@ -72,8 +117,8 @@ Finally, if you use a model that relies on Demucs (e.g. `musicgen-melody`) and w
 
 
 ## License
-* The code in this repository is released under the MIT license as found in the [LICENSE file](LICENSE).
-* The models weights in this repository are released under the CC-BY-NC 4.0 license as found in the [LICENSE_weights file](LICENSE_weights).
+* The code in this repository is released under the MIT license as found in the [LICENSE file](./audiocraft/LICENSE).
+* The models weights in this repository are released under the CC-BY-NC 4.0 license as found in the [LICENSE_weights file](./audiocraft/LICENSE_weights).
 
 
 ## Citation
@@ -89,4 +134,4 @@ For the general framework of AudioCraft, please cite the following.
 ```
 
 When referring to a specific model, please cite as mentioned in the model specific README, e.g
-[./docs/MUSICGEN.md](./docs/MUSICGEN.md), [./docs/AUDIOGEN.md](./docs/AUDIOGEN.md), etc.
+[./audiocraft/docs/MUSICGEN.md](./audiocraft/docs/MUSICGEN.md), [./audiocraft/docs/AUDIOGEN.md](./audiocraft/docs/AUDIOGEN.md), etc.

--- a/audiocraft/docs/AUDIOGEN.md
+++ b/audiocraft/docs/AUDIOGEN.md
@@ -22,7 +22,7 @@ See [the model card](../model_cards/AUDIOGEN_MODEL_CARD.md).
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 AudioCraft requires a GPU with at least 16 GB of memory for running inference with the medium-sized models (~1.5B parameters).
 

--- a/audiocraft/docs/ENCODEC.md
+++ b/audiocraft/docs/ENCODEC.md
@@ -16,7 +16,7 @@ and released checkpoints at this stage.
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 
 ## Training
@@ -174,7 +174,7 @@ Learn more about AudioCraft training pipelines in the [dedicated section](./TRAI
 
 ## License
 
-See license information in the [README](../README.md).
+See license information in the [README](../../README.md).
 
 [arxiv]: https://arxiv.org/abs/2210.13438
 [encodec_samples]: https://ai.honu.io/papers/encodec/samples.html

--- a/audiocraft/docs/JASCO.md
+++ b/audiocraft/docs/JASCO.md
@@ -18,7 +18,7 @@ See [the model card](../model_cards/JASCO_MODEL_CARD.md).
 
 ## Installation
 
-First, Please follow the AudioCraft installation instructions from the [README](../README.md).
+First, Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 Then, download and install chord_extractor from [source](http://www.isophonics.net/nnls-chroma)
 

--- a/audiocraft/docs/MAGNET.md
+++ b/audiocraft/docs/MAGNET.md
@@ -20,7 +20,7 @@ See [the model card](../model_cards/MAGNET_MODEL_CARD.md).
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 AudioCraft requires a GPU with at least 16 GB of memory for running inference with the medium-sized models (~1.5B parameters).
 

--- a/audiocraft/docs/MBD.md
+++ b/audiocraft/docs/MBD.md
@@ -12,7 +12,7 @@ MultiBand diffusion is a collection of 4 models that can decode tokens from
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 
 ## Usage
@@ -110,7 +110,7 @@ Learn more about AudioCraft training pipelines in the [dedicated section](./TRAI
 
 ## License
 
-See license information in the [README](../README.md).
+See license information in the [README](../../README.md).
 
 
 [arxiv]: https://arxiv.org/abs/2308.02560

--- a/audiocraft/docs/MUSICGEN.md
+++ b/audiocraft/docs/MUSICGEN.md
@@ -28,7 +28,7 @@ See [the model card](../model_cards/MUSICGEN_MODEL_CARD.md).
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 AudioCraft requires a GPU with at least 16 GB of memory for running inference with the medium-sized models (~1.5B parameters).
 

--- a/audiocraft/docs/MUSICGEN_STYLE.md
+++ b/audiocraft/docs/MUSICGEN_STYLE.md
@@ -19,7 +19,7 @@ See [the model card](../model_cards/MUSICGEN_STYLE_MODEL_CARD.md).
 
 ## Installation
 
-Please follow the AudioCraft installation instructions from the [README](../README.md).
+Please follow the AudioCraft installation instructions from the [README](../../README.md).
 
 MusicGen-Stem requires a GPU with at least 16 GB of memory for running inference with the medium-sized models (~1.5B parameters).
 

--- a/audiocraft/docs/TRAINING.md
+++ b/audiocraft/docs/TRAINING.md
@@ -8,7 +8,7 @@ AudioCraft training pipelines are designed to be research and experiment-friendl
 
 ## Environment setup
 
-For the base installation, follow the instructions from the [README.md](../README.md).
+For the base installation, follow the instructions from the [README.md](../../README.md).
 Below are some additional instructions for setting up the environment to train new models.
 
 ### Team and cluster configuration

--- a/audiocraft/docs/WATERMARKING.md
+++ b/audiocraft/docs/WATERMARKING.md
@@ -4,10 +4,10 @@ AudioCraft provides the training code and models for AudioSeal, a method for spe
 
 ## Installation and setup
 
-Make sure to install audiocraft version `1.4.0a1` or later, and with the `[wm]` extra (see [README](../README.md)).
+Make sure to install audiocraft version `1.4.0a1` or later, and with the `[wm]` extra (see [README](../../README.md)).
 Alternatively, you can just install audioseal yourself. To install AudioSeal, follow [Installation](https://github.com/facebookresearch/audioseal) guidelines in the AudioSeal repo.
 
-_NOTE_: Since we use AAC augmentation in our training loop, you need to install ffmpeg, or it will not work (See Section "Installation" in [README](../README.md)).
+_NOTE_: Since we use AAC augmentation in our training loop, you need to install ffmpeg, or it will not work (See Section "Installation" in [README](../../README.md)).
 
 Make sure you follow [steps for basic training setup](TRAINING.md) before starting.
 

--- a/audiocraft/setup.py
+++ b/audiocraft/setup.py
@@ -25,9 +25,9 @@ for line in open('audiocraft/__init__.py'):
         VERSION = context['__version__']
 
 HERE = Path(__file__).parent
-
+README_PATH = HERE.parent / "README.md"
 try:
-    with open(HERE / "README.md", encoding='utf-8') as f:
+    with open(README_PATH, encoding='utf-8') as f:
         long_description = '\n' + f.read()
 except FileNotFoundError:
     long_description = DESCRIPTION


### PR DESCRIPTION
## Summary
- move `audiocraft/README.md` to repository root
- update relative documentation paths
- document creating a Python virtual environment
- describe how to run Gradio demos and the PyQt GUI
- adjust setup script to read new README location

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6865ed89c0288332ac1f030c321f782b